### PR TITLE
Add Missing Package Reference

### DIFF
--- a/WowUp.Common/WowUp.Common.csproj
+++ b/WowUp.Common/WowUp.Common.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="protobuf-net" Version="3.0.29" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Unable to build the project without adding this reference.

I pulled down master and was unable to build it in VS2019 without first adding this package reference.