### PR TITLE
Bugfix for Issue #40

### DIFF
--- a/WowUp.WPF/Services/AddonService.cs
+++ b/WowUp.WPF/Services/AddonService.cs
@@ -176,7 +176,7 @@ namespace WowUp.WPF.Services
                 {
                     var newAddons = await ScanAddons(clientType);
                     addons = UpdateAddons(addons, newAddons);
-                    AddonListUpdated?.Invoke(this, new EventArgs());
+                    AddonListUpdated?.Invoke(this, EventArgs.Empty);
                 }
 
                 await SyncAddons(clientType, addons);

--- a/WowUp.WPF/Services/AddonService.cs
+++ b/WowUp.WPF/Services/AddonService.cs
@@ -46,6 +46,7 @@ namespace WowUp.WPF.Services
         public event AddonEventHandler AddonInstalled;
         public event AddonEventHandler AddonUpdated;
         public event AddonStateEventHandler AddonStateChanged;
+        public event AddonListUpdatedEventHandler AddonListUpdated;
 
         public string BackupPath => Path.Combine(FileUtilities.AppDataPath, BackupFolder);
 
@@ -175,10 +176,10 @@ namespace WowUp.WPF.Services
                 {
                     var newAddons = await ScanAddons(clientType);
                     addons = UpdateAddons(addons, newAddons);
+                    AddonListUpdated?.Invoke(this, new EventArgs());
                 }
 
                 await SyncAddons(clientType, addons);
-
                 return addons;
             }
             catch(Exception ex)

--- a/WowUp.WPF/Services/AnalyticsService.cs
+++ b/WowUp.WPF/Services/AnalyticsService.cs
@@ -150,7 +150,7 @@ namespace WowUp.WPF.Services
 
                 await SetAppCenterEnabled(true);
             }
-            catch(Exception ex)
+            catch(Exception)
             {
                 // eat
             }

--- a/WowUp.WPF/Services/Contracts/IAddonService.cs
+++ b/WowUp.WPF/Services/Contracts/IAddonService.cs
@@ -10,6 +10,7 @@ namespace WowUp.WPF.Services.Contracts
 {
     public delegate void AddonEventHandler(object sender, AddonEventArgs e);
     public delegate void AddonStateEventHandler(object sender, AddonStateEventArgs e);
+    public delegate void AddonListUpdatedEventHandler(object sender, EventArgs e);
 
     public interface IAddonService
     {
@@ -17,6 +18,7 @@ namespace WowUp.WPF.Services.Contracts
         event AddonEventHandler AddonInstalled;
         event AddonEventHandler AddonUpdated;
         event AddonStateEventHandler AddonStateChanged;
+        event AddonListUpdatedEventHandler AddonListUpdated;
 
         string BackupPath { get; }
 

--- a/WowUp.WPF/Utilities/FileUtilities.cs
+++ b/WowUp.WPF/Utilities/FileUtilities.cs
@@ -50,7 +50,7 @@ namespace WowUp.WPF.Utilities
                 File.WriteAllText(testPath, string.Empty);
                 return true;
             }
-            catch(Exception ex)
+            catch(Exception)
             {
                 return false;
             }

--- a/WowUp.WPF/ViewModels/GetAddonsViewModel.cs
+++ b/WowUp.WPF/ViewModels/GetAddonsViewModel.cs
@@ -77,6 +77,11 @@ namespace WowUp.WPF.ViewModels
                 OnRefresh();
             };
 
+            _addonService.AddonListUpdated += (sender, args) =>
+            {
+                OnRefresh();
+            }; 
+
             _sessionService.SessionChanged += (sender, args) =>
             {
                 SelectedClientType = args.SessionState.SelectedClientType;


### PR DESCRIPTION
Bugfix for Issue #40.
Implemented a new event which fires after a rescan or the first start scan, which will cause a refresh on the "Get Addons" Tab.

I also removed the unused exception handler variables from HasWriteAccess() in FileUtilities.cs and StartAppCenter() in AnalyticsService.cs as those are unnecessary and causes compiler warnings.