### PR TITLE
Curse dependency support #24

### DIFF
--- a/WowUp.Common/Enums/AddonDependencyType.cs
+++ b/WowUp.Common/Enums/AddonDependencyType.cs
@@ -1,0 +1,10 @@
+﻿namespace WowUp.Common.Enums
+{
+    public enum AddonDependencyType
+    {
+        EmbeddedLib = 1,
+        Optional = 2,
+        Required = 3,
+        Other = 4
+    }
+}

--- a/WowUp.Common/Models/Addons/AddonSearchResultDependency.cs
+++ b/WowUp.Common/Models/Addons/AddonSearchResultDependency.cs
@@ -1,0 +1,10 @@
+﻿using WowUp.Common.Enums;
+
+namespace WowUp.Common.Models.Addons
+{
+    public class AddonSearchResultDependency
+    {
+        public int AddonId { get; set; }
+        public AddonDependencyType Type { get; set; }
+    }
+}

--- a/WowUp.Common/Models/Addons/AddonSearchResultFile.cs
+++ b/WowUp.Common/Models/Addons/AddonSearchResultFile.cs
@@ -12,5 +12,6 @@ namespace WowUp.Common.Models.Addons
         public string GameVersion { get; set; }
         public string DownloadUrl { get; set; }
         public DateTime ReleaseDate { get; set; }
+        public IEnumerable<AddonSearchResultDependency> Dependencies { get; set; }
     }
 }

--- a/WowUp.Common/Models/Curse/CurseDependency.cs
+++ b/WowUp.Common/Models/Curse/CurseDependency.cs
@@ -4,7 +4,7 @@
     {
         public long Id { get; set; }
         public int AddonId { get; set; }
-        public int Type { get; set; }
+        public CurseDependencyType Type { get; set; }
         public int FileId { get; set; }
     }
 }

--- a/WowUp.Common/Models/Curse/CurseDependencyType.cs
+++ b/WowUp.Common/Models/Curse/CurseDependencyType.cs
@@ -1,0 +1,28 @@
+﻿using WowUp.Common.Enums;
+
+namespace WowUp.Common.Models.Curse
+{
+    public enum CurseDependencyType
+    {
+        EmbeddedLib = 1,
+        Optional = 2,
+        Required = 3,
+        Tool = 4,
+        Incomplete = 5,
+        Include = 6
+    }
+
+    public static class CurseDependencyExtensions
+    {
+        public static AddonDependencyType AsAddonDependencyType(this CurseDependencyType dependencyType)
+        {
+            return dependencyType switch
+            {
+                CurseDependencyType.EmbeddedLib => AddonDependencyType.EmbeddedLib,
+                CurseDependencyType.Optional => AddonDependencyType.Optional,
+                CurseDependencyType.Required => AddonDependencyType.Required,
+                _ => AddonDependencyType.Other
+            };
+        }
+    }
+}

--- a/WowUp.Common/Models/Curse/CurseDependencyType.cs
+++ b/WowUp.Common/Models/Curse/CurseDependencyType.cs
@@ -8,7 +8,7 @@ namespace WowUp.Common.Models.Curse
         Optional = 2,
         Required = 3,
         Tool = 4,
-        Incomplete = 5,
+        Incompatible = 5,
         Include = 6
     }
 

--- a/WowUp.WPF/AddonProviders/CurseAddonProvider.cs
+++ b/WowUp.WPF/AddonProviders/CurseAddonProvider.cs
@@ -413,7 +413,12 @@ namespace WowUp.WPF.AddonProviders
                     DownloadUrl = lf.DownloadUrl,
                     Folders = GetFolderNames(lf),
                     GameVersion = GetGameVersion(lf),
-                    ReleaseDate = lf.FileDate
+                    ReleaseDate = lf.FileDate,
+                    Dependencies = lf.Dependencies.Select(dep => new AddonSearchResultDependency
+                    {
+                        AddonId = dep.AddonId,
+                        Type = dep.Type.AsAddonDependencyType()
+                    })
                 });
 
                 return new AddonSearchResult

--- a/WowUp.WPF/AddonProviders/CurseAddonProvider.cs
+++ b/WowUp.WPF/AddonProviders/CurseAddonProvider.cs
@@ -414,11 +414,12 @@ namespace WowUp.WPF.AddonProviders
                     Folders = GetFolderNames(lf),
                     GameVersion = GetGameVersion(lf),
                     ReleaseDate = lf.FileDate,
-                    Dependencies = lf.Dependencies.Select(dep => new AddonSearchResultDependency
-                    {
-                        AddonId = dep.AddonId,
-                        Type = dep.Type.AsAddonDependencyType()
-                    })
+                    Dependencies = lf.Dependencies != null ? 
+                        lf.Dependencies.Select(dep => new AddonSearchResultDependency
+                        {
+                            AddonId = dep.AddonId,
+                            Type = dep.Type.AsAddonDependencyType()
+                        }) : Enumerable.Empty<AddonSearchResultDependency>()
                 });
 
                 return new AddonSearchResult

--- a/WowUp.WPF/AddonProviders/GitHubAddonProvider.cs
+++ b/WowUp.WPF/AddonProviders/GitHubAddonProvider.cs
@@ -88,7 +88,8 @@ namespace WowUp.WPF.AddonProviders
                 Folders = new List<string> { name },
                 GameVersion = string.Empty,
                 Version = asset.Name,
-                ReleaseDate = asset.CreatedAt
+                ReleaseDate = asset.CreatedAt,
+                Dependencies = Enumerable.Empty<AddonSearchResultDependency>()
             };
 
             var searchResult = new AddonSearchResult

--- a/WowUp.WPF/AddonProviders/TukUiAddonProvider.cs
+++ b/WowUp.WPF/AddonProviders/TukUiAddonProvider.cs
@@ -203,7 +203,8 @@ namespace WowUp.WPF.AddonProviders
                 DownloadUrl = addon.Url,
                 GameVersion = addon.Patch,
                 Version = addon.Version,
-                ReleaseDate = addon.LastUpdate
+                ReleaseDate = addon.LastUpdate,
+                Dependencies = Enumerable.Empty<AddonSearchResultDependency>()
             };
 
             return new AddonSearchResult

--- a/WowUp.WPF/AddonProviders/WowInterfaceAddonProvider.cs
+++ b/WowUp.WPF/AddonProviders/WowInterfaceAddonProvider.cs
@@ -207,7 +207,8 @@ namespace WowUp.WPF.AddonProviders
                     DownloadUrl = response.DownloadUri,
                     Folders = new[] { folderName },
                     GameVersion = string.Empty,
-                    ReleaseDate = DateTime.UtcNow
+                    ReleaseDate = DateTime.UtcNow,
+                    Dependencies = Enumerable.Empty<AddonSearchResultDependency>()
                 };
 
                 return new AddonSearchResult

--- a/WowUp.WPF/App.xaml.cs
+++ b/WowUp.WPF/App.xaml.cs
@@ -125,6 +125,7 @@ namespace WowUp.WPF
 
             services.AddSingleton<IAddonRepository, AddonRepository>();
             services.AddSingleton<IPreferenceRepository, PreferenceRepository>();
+            services.AddSingleton<IDependencyRepository, DependencyRepository>();
         }
 
         private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)

--- a/WowUp.WPF/Entities/Addon.cs
+++ b/WowUp.WPF/Entities/Addon.cs
@@ -1,5 +1,6 @@
 ﻿using SQLite;
 using System;
+using System.Collections.Generic;
 using WowUp.Common.Enums;
 
 namespace WowUp.WPF.Entities
@@ -150,5 +151,8 @@ namespace WowUp.WPF.Entities
             get => _updatedAt;
             set { SetProperty(ref _updatedAt, value); }
         }
+
+        [Ignore]
+        public IEnumerable<Addon> Dependencies { get; set; }
     }
 }

--- a/WowUp.WPF/Entities/AddonDependency.cs
+++ b/WowUp.WPF/Entities/AddonDependency.cs
@@ -1,0 +1,32 @@
+﻿using SQLite;
+using WowUp.Common.Enums;
+
+namespace WowUp.WPF.Entities
+{
+    [Table("AddonDependencies")]
+    public class AddonDependency : BaseEntity
+    {
+        private int _addonId;
+        [NotNull, Indexed(Name = "CompositeKey", Order = 1)]
+        public int AddonId
+        {
+            get => _addonId;
+            set => SetProperty(ref _addonId, value);
+        }
+
+        private int _dependencyId;
+        [NotNull, Indexed(Name = "CompositeKey", Order = 2)]
+        public int DependencyId
+        {
+            get => _dependencyId;
+            set => SetProperty(ref _dependencyId, value);
+        }
+
+        private AddonDependencyType _type;
+        public AddonDependencyType Type
+        {
+            get => _type;
+            set => SetProperty(ref _type, value);
+        }
+    }
+}

--- a/WowUp.WPF/Repositories/Contracts/IDependencyRepository.cs
+++ b/WowUp.WPF/Repositories/Contracts/IDependencyRepository.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using WowUp.WPF.Entities;
+
+namespace WowUp.WPF.Repositories.Contracts
+{
+    public interface IDependencyRepository : IDataStore<AddonDependency>
+    {
+        IEnumerable<AddonDependency> GetAddonDependencies(Addon addon);
+
+        IEnumerable<AddonDependency> GetDependentAddons(Addon addon);
+    }
+}

--- a/WowUp.WPF/Repositories/DependencyRepository.cs
+++ b/WowUp.WPF/Repositories/DependencyRepository.cs
@@ -1,0 +1,101 @@
+﻿using SQLite;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WowUp.WPF.Entities;
+using WowUp.WPF.Repositories.Base;
+using WowUp.WPF.Repositories.Contracts;
+
+namespace WowUp.WPF.Repositories
+{
+    public class DependencyRepository : BaseEntityRepository<AddonDependency>, IDependencyRepository
+    {
+        public bool AddItem(AddonDependency item)
+        {
+            return SaveItem(item);
+        }
+
+        public bool SaveItem(AddonDependency item)
+        {
+            lock (_collisionLock)
+            {
+                _database.Insert(item);
+            }
+
+            return true;
+        }
+
+        public bool UpdateItem(AddonDependency item)
+        {
+            return SaveItem(item);
+        }
+
+        public bool DeleteItem(AddonDependency addon)
+        {
+            lock (_collisionLock)
+            {
+                _database.Execute("DELETE FROM AddonDependencies WHERE AddonId = ? AND DependencyId = ?", addon.AddonId, addon.DependencyId);
+            }
+            return true;
+        }
+
+        public bool DeleteItems(IEnumerable<AddonDependency> addons)
+        {
+            lock (_collisionLock)
+            {
+                foreach (var addon in addons)
+                {
+                    DeleteItem(addon);
+                }
+            }
+            return true;
+        }
+
+        public IEnumerable<AddonDependency> Query(Func<TableQuery<AddonDependency>, TableQuery<AddonDependency>> action)
+        {
+            lock (_collisionLock)
+            {
+                var query = action.Invoke(_database.Table<AddonDependency>());
+                return query.AsEnumerable();
+            }
+        }
+
+        public AddonDependency Query(Func<TableQuery<AddonDependency>, AddonDependency> action)
+        {
+            lock (_collisionLock)
+            {
+                return action.Invoke(_database.Table<AddonDependency>());
+            }
+        }
+
+        public IEnumerable<AddonDependency> GetAddonDependencies(Addon addon)
+        {
+            return Query(dependencies =>
+                dependencies.Where(ad => ad.AddonId == addon.Id));
+        }
+
+        public IEnumerable<AddonDependency> GetDependentAddons(Addon addon)
+        {
+            return Query(dependencies =>
+                dependencies.Where(ad => ad.DependencyId == addon.Id));
+        }
+
+        public bool AddItems(IEnumerable<AddonDependency> items)
+        {
+            return SaveItems(items);
+        }
+
+        public bool SaveItems(IEnumerable<AddonDependency> items)
+        {
+            lock (_collisionLock)
+            {
+                foreach (var item in items)
+                {
+                    _database.Insert(item);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/WowUp.WPF/Services/AnalyticsService.cs
+++ b/WowUp.WPF/Services/AnalyticsService.cs
@@ -150,7 +150,7 @@ namespace WowUp.WPF.Services
 
                 await SetAppCenterEnabled(true);
             }
-            catch(Exception ex)
+            catch(Exception)
             {
                 // eat
             }

--- a/WowUp.WPF/Utilities/FileUtilities.cs
+++ b/WowUp.WPF/Utilities/FileUtilities.cs
@@ -50,7 +50,7 @@ namespace WowUp.WPF.Utilities
                 File.WriteAllText(testPath, string.Empty);
                 return true;
             }
-            catch(Exception ex)
+            catch(Exception)
             {
                 return false;
             }


### PR DESCRIPTION
This implements support for curseforge dependencies.
Dependencies that are marked as "required" will now be installed/uninstalled with the selected addon, uninstall will only happen if no other addon depents upon it.
The relations will be stored in the sqlite database in a loosely manner (due to lack of relationship/composite primary key support of the used sqlite-net API)

Related Issue: #24 