### PR TITLE
Added download count translation for Norwegian Bokmål.

### DIFF
--- a/wowup-electron/src/assets/i18n/nb.json
+++ b/wowup-electron/src/assets/i18n/nb.json
@@ -67,7 +67,7 @@
     },
     "OPTIONS": {
       "APPLICATION": {
-        "ENABLE_SYSTEM_NOTIFICATIONS_LABEL": "Aktiver systemvarsler",
+        "ENABLE_SYSTEM_NOTIFICATIONS_LABEL": "Aktiver Systemvarsler",
         "ENABLE_SYSTEM_NOTIFICATIONS_DESCRIPTION": "Aktiver/Deaktiver forskjellige systemvarsler, foreksempel: automatisk oppdatering av addons.",
         "MINIMIZE_ON_CLOSE_LABEL": "Minimer ved lukking",
         "MINIMIZE_ON_CLOSE_DESCRIPTION_MAC": "Når WowUp-vinduet lukkes, minimer til menylinjen.",
@@ -146,6 +146,11 @@
       "UPDATE": "Oppdater",
       "INSTALL": "Installer",
       "UPTODATE": "Oppdatert"
+    },
+    "DOWNLOAD_COUNT": {
+      "BILLION": "milliarder",
+      "MILLION": "millioner",
+      "THOUSAND": "tusen"
     }
   }
 }


### PR DESCRIPTION
Note:

In norwegian the counts should support plural form.

1 million would be: 1 million
while 
2 million would be 2 million**er**

1 billion would be 1 milliard
2 billion would be 2 milliard**er**

etc.

I just translated it to plural form for now as that sounds the most weird if said in singular form.