### PR TITLE
[electron] Added "installedAt" to be displayed as "Updated At"

### DIFF
--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.html
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.html
@@ -69,6 +69,16 @@
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="addon.installedAt">
+        <th mat-header-cell mat-sort-header *matHeaderCellDef>
+          {{'PAGES.MY_ADDONS.TABLE.UPDATED_AT_COLUMN_HEADER' | translate}}
+        </th>
+        <td mat-cell *matCellDef="let element" class="cell-padding" [matTooltip]="element.addon.installedAt | date:'short'"
+            matTooltipPosition="above" matTooltipShowDelay="500">
+          {{element.addon.installedAt | relativeDuration}}
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="addon.latestVersion">
         <th mat-header-cell mat-sort-header *matHeaderCellDef>
           {{'PAGES.MY_ADDONS.TABLE.LATEST_VERSION_COLUMN_HEADER' | translate}}

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.html
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.html
@@ -70,7 +70,7 @@
       </ng-container>
 
       <ng-container matColumnDef="addon.installedAt">
-        <th mat-header-cell mat-sort-header *matHeaderCellDef>
+        <th class="installed-at-cell" mat-header-cell mat-sort-header *matHeaderCellDef>
           {{'PAGES.MY_ADDONS.TABLE.UPDATED_AT_COLUMN_HEADER' | translate}}
         </th>
         <td mat-cell *matCellDef="let element" class="cell-padding" [matTooltip]="element.addon.installedAt | date:'short'"
@@ -89,7 +89,7 @@
       </ng-container>
 
       <ng-container matColumnDef="addon.releasedAt">
-        <th mat-header-cell mat-sort-header *matHeaderCellDef>
+        <th class="released-at-cell" mat-header-cell mat-sort-header *matHeaderCellDef>
           {{'PAGES.MY_ADDONS.TABLE.RELEASED_AT_COLUMN_HEADER' | translate}}
         </th>
         <td mat-cell *matCellDef="let element" class="cell-padding"

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.scss
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.scss
@@ -13,7 +13,7 @@
   .right-container {
     display: flex;
     flex-direction: row;
-  
+
     .filter-container {
       padding-top: 1em;
     }
@@ -23,7 +23,7 @@
       flex-direction: row;
       align-items: center;
       margin-left: 1em;
-  
+
       button {
         &:not(:last-child) {
           margin-right: 0.5em;
@@ -79,6 +79,10 @@
     min-width: 110px;
   }
 
+  .installed-at-cell, .released-at-cell {
+    min-width: 100px;
+  }
+
   .status-column {
     // display: flex;
     width: 130px;
@@ -129,7 +133,7 @@
   text-align: left;
 }
 .provider-column {
-  min-width: 60px;
+  min-width: 70px;
 }
 
 .column-menu {

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
@@ -72,6 +72,12 @@ export class MyAddonsComponent implements OnInit, OnDestroy {
     { name: "addon.name", display: "Addon", visible: true },
     { name: "displayState", display: "Status", visible: true },
     {
+      name: "addon.installedAt",
+      display: "Updated At",
+      visible: true,
+      allowToggle: true,
+    },
+    {
       name: "addon.latestVersion",
       display: "Latest Version",
       visible: true,

--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -509,6 +509,7 @@ export class AddonService {
 
       newAddon.autoUpdateEnabled = existingAddon.autoUpdateEnabled;
       newAddon.isIgnored = existingAddon.isIgnored;
+      newAddon.installedAt = existingAddon.installedAt;
     });
 
     return newAddons;

--- a/wowup-electron/src/assets/i18n/de.json
+++ b/wowup-electron/src/assets/i18n/de.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Aktuelle Version",
         "PROVIDER_COLUMN_HEADER": "Anbieter",
         "RELEASED_AT_COLUMN_HEADER": "Erscheinungsdatum",
-        "STATUS_COLUMN_HEADER": "Status"
+        "STATUS_COLUMN_HEADER": "Status",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Latest Version",
         "PROVIDER_COLUMN_HEADER": "Provider",
         "RELEASED_AT_COLUMN_HEADER": "Released At",
-        "STATUS_COLUMN_HEADER": "Status"
+        "STATUS_COLUMN_HEADER": "Status",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/es.json
+++ b/wowup-electron/src/assets/i18n/es.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Última Versión",
         "PROVIDER_COLUMN_HEADER": "Proveedor",
         "RELEASED_AT_COLUMN_HEADER": "RELEASED_AT_COLUMN_HEADER",
-        "STATUS_COLUMN_HEADER": "Situación"
+        "STATUS_COLUMN_HEADER": "Situación",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/fr.json
+++ b/wowup-electron/src/assets/i18n/fr.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Dernière version",
         "PROVIDER_COLUMN_HEADER": "Fournisseur",
         "RELEASED_AT_COLUMN_HEADER": "RELEASED_AT_COLUMN_HEADER",
-        "STATUS_COLUMN_HEADER": "Statut"
+        "STATUS_COLUMN_HEADER": "Statut",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/it.json
+++ b/wowup-electron/src/assets/i18n/it.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Ultima Versione",
         "PROVIDER_COLUMN_HEADER": "Provveditore",
         "RELEASED_AT_COLUMN_HEADER": "RELEASED_AT_COLUMN_HEADER",
-        "STATUS_COLUMN_HEADER": "Stato"
+        "STATUS_COLUMN_HEADER": "Stato",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/ko.json
+++ b/wowup-electron/src/assets/i18n/ko.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Latest Version",
         "PROVIDER_COLUMN_HEADER": "Provider",
         "RELEASED_AT_COLUMN_HEADER": "Released At",
-        "STATUS_COLUMN_HEADER": "Status"
+        "STATUS_COLUMN_HEADER": "Status",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/nb.json
+++ b/wowup-electron/src/assets/i18n/nb.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Siste Versjon",
         "PROVIDER_COLUMN_HEADER": "Leverandør",
         "RELEASED_AT_COLUMN_HEADER": "Utgivelsesdato",
-        "STATUS_COLUMN_HEADER": "Status"
+        "STATUS_COLUMN_HEADER": "Status",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/pt.json
+++ b/wowup-electron/src/assets/i18n/pt.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Ultima versão",
         "PROVIDER_COLUMN_HEADER": "Provedor",
         "RELEASED_AT_COLUMN_HEADER": "RELEASED_AT_COLUMN_HEADER",
-        "STATUS_COLUMN_HEADER": "Estado"
+        "STATUS_COLUMN_HEADER": "Estado",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",

--- a/wowup-electron/src/assets/i18n/ru.json
+++ b/wowup-electron/src/assets/i18n/ru.json
@@ -134,7 +134,7 @@
         "PROVIDER_COLUMN_HEADER": "Источник",
         "RELEASED_AT_COLUMN_HEADER": "Выпущена",
         "STATUS_COLUMN_HEADER": "Статус",
-        "UPDATED_AT_COLUMN_HEADER": "Updated At"
+        "UPDATED_AT_COLUMN_HEADER": "Обновлена"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "Это действие удалит все относящиеся папки модификации из вашей папки World of Warcraft.",

--- a/wowup-electron/src/assets/i18n/ru.json
+++ b/wowup-electron/src/assets/i18n/ru.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "Последняя версия",
         "PROVIDER_COLUMN_HEADER": "Источник",
         "RELEASED_AT_COLUMN_HEADER": "Выпущена",
-        "STATUS_COLUMN_HEADER": "Статус"
+        "STATUS_COLUMN_HEADER": "Статус",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "Это действие удалит все относящиеся папки модификации из вашей папки World of Warcraft.",

--- a/wowup-electron/src/assets/i18n/zh.json
+++ b/wowup-electron/src/assets/i18n/zh.json
@@ -133,7 +133,8 @@
         "LATEST_VERSION_COLUMN_HEADER": "最新版本",
         "PROVIDER_COLUMN_HEADER": "提供商",
         "RELEASED_AT_COLUMN_HEADER": "RELEASED_AT_COLUMN_HEADER",
-        "STATUS_COLUMN_HEADER": "状态"
+        "STATUS_COLUMN_HEADER": "状态",
+        "UPDATED_AT_COLUMN_HEADER": "Updated At"
       },
       "UNINSTALL_POPUP": {
         "CONFIRMATION_ACTION_EXPLANATION": "This will remove all related folders from your World of Warcraft folder.",


### PR DESCRIPTION
This PR adds the much requested "Updated At" column. It currently works as following when re-scanning: 
 - if the addon already existed, take over the `installedAt` value
 - if the addon isn't recognized, pick whatever was already filled in (`now` atm)
 - when an addon is updated, it will get a new `installedAt` value, which translates to "Updated At" in the user interface

Closes #82

### Overview
My last re-scan was 2 hours ago on this screenshot, which was the old behavior (always new `installedAt`).
![image](https://user-images.githubusercontent.com/1754678/97086101-abfabc00-1621-11eb-8258-55f5e92f2dc2.png)

### Updating
After updating it will receive the new `installedAt` value
![image](https://user-images.githubusercontent.com/1754678/97086151-e6645900-1621-11eb-8f66-756c500f5b7b.png)
