### PR TITLE
[Electron/fix] Addon info dialog Update button was showing Install

### DIFF
--- a/wowup-electron/src/app/business-objects/my-addon-list-item.ts
+++ b/wowup-electron/src/app/business-objects/my-addon-list-item.ts
@@ -36,7 +36,8 @@ export class AddonViewModel {
 
   get isUpToDate() {
     return (
-      !this.isInstalling && this.displayState === AddonDisplayState.UpToDate
+      !this.isInstalling &&
+      this.addon.installedVersion === this.addon.latestVersion
     );
   }
 
@@ -79,6 +80,10 @@ export class AddonViewModel {
   constructor(addon?: Addon) {
     this.addon = addon;
     this.stateTextTranslationKey = this.getStateTextTranslationKey();
+  }
+
+  public clone() {
+    return new AddonViewModel(this.addon);
   }
 
   public onClicked() {

--- a/wowup-electron/src/app/business-objects/my-addon-list-item.ts
+++ b/wowup-electron/src/app/business-objects/my-addon-list-item.ts
@@ -9,7 +9,7 @@ export class AddonViewModel {
   public installState: AddonInstallState = AddonInstallState.Unknown;
   public isInstalling: boolean = false;
   public installProgress: number = 0;
-  public statusText: string = "";
+  public stateTextTranslationKey: string = "";
   public selected: boolean = false;
 
   get hasThumbnail() {
@@ -78,26 +78,27 @@ export class AddonViewModel {
 
   constructor(addon?: Addon) {
     this.addon = addon;
-    this.statusText = this.getStateText();
+    this.stateTextTranslationKey = this.getStateTextTranslationKey();
   }
 
   public onClicked() {
     this.selected = !this.selected;
   }
 
-  public getStateText() {
+  public getStateTextTranslationKey() {
     switch (this.displayState) {
       case AddonDisplayState.UpToDate:
-        return "Up to Date";
+        return "COMMON.ADDON_STATE.UPTODATE";
       case AddonDisplayState.Ignored:
-        return "Ignored";
+        return "COMMON.ADDON_STATE.IGNORED";
       case AddonDisplayState.Update:
+        return "COMMON.ADDON_STATE.UPDATE";
       case AddonDisplayState.Install:
-        return "Install";
+        return "COMMON.ADDON_STATE.INSTALL";
       case AddonDisplayState.Unknown:
       default:
         console.log("Unhandled display state", this.displayState);
-        return "";
+        return "COMMON.ADDON_STATE.UNKNOWN";
     }
   }
 }

--- a/wowup-electron/src/app/components/addon-detail/addon-detail.component.ts
+++ b/wowup-electron/src/app/components/addon-detail/addon-detail.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Inject,
@@ -23,6 +24,7 @@ export interface AddonDetailModel {
   selector: "app-addon-detail",
   templateUrl: "./addon-detail.component.html",
   styleUrls: ["./addon-detail.component.scss"],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AddonDetailComponent implements OnInit, OnDestroy {
   private readonly _subscriptions: Subscription[] = [];

--- a/wowup-electron/src/app/components/addon-update-button/addon-update-button.component.ts
+++ b/wowup-electron/src/app/components/addon-update-button/addon-update-button.component.ts
@@ -117,7 +117,11 @@ export class AddonUpdateButtonComponent implements OnInit, OnDestroy {
       );
     }
 
-    return this.listItem?.statusText;
+    if (!this.listItem) {
+      return null;
+    }
+
+    return this._translateService.instant(this.listItem.stateTextTranslationKey);
   }
 
   private getInstallStateText(installState: AddonInstallState) {

--- a/wowup-electron/src/app/components/addon-update-button/addon-update-button.component.ts
+++ b/wowup-electron/src/app/components/addon-update-button/addon-update-button.component.ts
@@ -118,7 +118,7 @@ export class AddonUpdateButtonComponent implements OnInit, OnDestroy {
     }
 
     if (!this.listItem) {
-      return null;
+      return "";
     }
 
     return this._translateService.instant(this.listItem.stateTextTranslationKey);

--- a/wowup-electron/src/app/components/my-addon-status-column/my-addon-status-column.component.html
+++ b/wowup-electron/src/app/components/my-addon-status-column/my-addon-status-column.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <app-addon-update-button *ngIf="showStatusText === false" [listItem]="listItem"></app-addon-update-button>
   <div *ngIf="showStatusText === true" class="status-text" [ngClass]="{ ignored: listItem.isIgnored }">
-    {{ getStatusText() }}
+    {{ getStatusText() | translate }}
   </div>
   <mat-icon *ngIf="this.listItem.isAutoUpdate === true" class="auto-update-icon"
     [matTooltip]="'PAGES.MY_ADDONS.TABLE.AUTO_UPDATE_ICON_TOOLTIP' | translate">

--- a/wowup-electron/src/app/components/my-addon-status-column/my-addon-status-column.component.ts
+++ b/wowup-electron/src/app/components/my-addon-status-column/my-addon-status-column.component.ts
@@ -40,7 +40,7 @@ export class MyAddonStatusColumnComponent implements OnInit, OnDestroy {
     }
 
     if (!this.listItem) {
-      return null;
+      return "";
     }
 
     return this._translateService.instant(this.listItem.stateTextTranslationKey);

--- a/wowup-electron/src/app/components/my-addon-status-column/my-addon-status-column.component.ts
+++ b/wowup-electron/src/app/components/my-addon-status-column/my-addon-status-column.component.ts
@@ -39,7 +39,11 @@ export class MyAddonStatusColumnComponent implements OnInit, OnDestroy {
       return this._translateService.instant("COMMON.ADDON_STATE.UPTODATE");
     }
 
-    return this.listItem?.statusText;
+    if (!this.listItem) {
+      return null;
+    }
+
+    return this._translateService.instant(this.listItem.stateTextTranslationKey);
   }
 
   public onUpdateButtonUpdated() {

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
@@ -149,7 +149,7 @@ export class MyAddonsComponent implements OnInit, OnDestroy {
         listItem.isInstalling =
           evt.installState === AddonInstallState.Installing ||
           evt.installState === AddonInstallState.Downloading;
-        listItem.statusText = this.getInstallStateText(evt.installState);
+        listItem.stateTextTranslationKey = this.getInstallStateTextTranslationKey(evt.installState);
         listItem.installProgress = evt.progress;
         listItem.installState = evt.installState;
         if (listItemIdx !== -1) {
@@ -519,7 +519,6 @@ export class MyAddonsComponent implements OnInit, OnDestroy {
       if (evt.checked) {
         listItem.addon.autoUpdateEnabled = false;
       }
-      listItem.statusText = listItem.getStateText();
       this.addonService.saveAddon(listItem.addon);
     });
 
@@ -714,22 +713,20 @@ export class MyAddonsComponent implements OnInit, OnDestroy {
     );
   }
 
-  private getInstallStateText(installState: AddonInstallState) {
+  private getInstallStateTextTranslationKey(installState: AddonInstallState) {
     switch (installState) {
       case AddonInstallState.BackingUp:
-        return this._translateService.instant("COMMON.ADDON_STATUS.BACKINGUP");
+        return "COMMON.ADDON_STATUS.BACKINGUP";
       case AddonInstallState.Complete:
-        return this._translateService.instant("COMMON.ADDON_STATE.UPTODATE");
+        return "COMMON.ADDON_STATE.UPTODATE";
       case AddonInstallState.Downloading:
-        return this._translateService.instant(
-          "COMMON.ADDON_STATUS.DOWNLOADING"
-        );
+        return "COMMON.ADDON_STATUS.DOWNLOADING";
       case AddonInstallState.Installing:
-        return this._translateService.instant("COMMON.ADDON_STATUS.INSTALLING");
+        return "COMMON.ADDON_STATUS.INSTALLING";
       case AddonInstallState.Pending:
-        return this._translateService.instant("COMMON.ADDON_STATUS.PENDING");
+        return "COMMON.ADDON_STATUS.PENDING";
       default:
-        return "";
+        return "COMMON.ADDON_STATUS.UNKNOWN";
     }
   }
 }

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
@@ -149,7 +149,9 @@ export class MyAddonsComponent implements OnInit, OnDestroy {
         listItem.isInstalling =
           evt.installState === AddonInstallState.Installing ||
           evt.installState === AddonInstallState.Downloading;
-        listItem.stateTextTranslationKey = this.getInstallStateTextTranslationKey(evt.installState);
+        listItem.stateTextTranslationKey = this.getInstallStateTextTranslationKey(
+          evt.installState
+        );
         listItem.installProgress = evt.progress;
         listItem.installState = evt.installState;
         if (listItemIdx !== -1) {
@@ -276,7 +278,7 @@ export class MyAddonsComponent implements OnInit, OnDestroy {
 
   public openDetailDialog(listItem: AddonViewModel) {
     const data: AddonDetailModel = {
-      listItem: Object.assign({}, listItem),
+      listItem: listItem.clone(),
     };
 
     const dialogRef = this._dialog.open(AddonDetailComponent, {

--- a/wowup-electron/src/assets/i18n/de.json
+++ b/wowup-electron/src/assets/i18n/de.json
@@ -8,6 +8,7 @@
       "IGNORED": "Ignorieren",
       "INSTALL": "Installieren",
       "UNINSTALL": "Deinstallieren",
+      "UNKNOWN": "",
       "UPDATE": "Aktualisieren",
       "UPTODATE": "Aktuell"
     },

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -8,6 +8,7 @@
       "IGNORED": "Ignored",
       "INSTALL": "Install",
       "UNINSTALL": "Uninstall",
+      "UNKNOWN": "",
       "UPDATE": "Update",
       "UPTODATE": "Up to date"
     },

--- a/wowup-electron/src/assets/i18n/es.json
+++ b/wowup-electron/src/assets/i18n/es.json
@@ -8,6 +8,7 @@
       "IGNORED": "IGNORED",
       "INSTALL": "INSTALL",
       "UNINSTALL": "UNINSTALL",
+      "UNKNOWN": "",
       "UPDATE": "UPDATE",
       "UPTODATE": "UPTODATE"
     },

--- a/wowup-electron/src/assets/i18n/fr.json
+++ b/wowup-electron/src/assets/i18n/fr.json
@@ -8,6 +8,7 @@
       "IGNORED": "IGNORED",
       "INSTALL": "INSTALL",
       "UNINSTALL": "UNINSTALL",
+      "UNKNOWN": "",
       "UPDATE": "UPDATE",
       "UPTODATE": "UPTODATE"
     },

--- a/wowup-electron/src/assets/i18n/it.json
+++ b/wowup-electron/src/assets/i18n/it.json
@@ -8,6 +8,7 @@
       "IGNORED": "IGNORED",
       "INSTALL": "INSTALL",
       "UNINSTALL": "UNINSTALL",
+      "UNKNOWN": "",
       "UPDATE": "UPDATE",
       "UPTODATE": "UPTODATE"
     },

--- a/wowup-electron/src/assets/i18n/ko.json
+++ b/wowup-electron/src/assets/i18n/ko.json
@@ -8,6 +8,7 @@
       "IGNORED": "Ignored",
       "INSTALL": "Install",
       "UNINSTALL": "Uninstall",
+      "UNKNOWN": "",
       "UPDATE": "Update",
       "UPTODATE": "Up to date"
     },

--- a/wowup-electron/src/assets/i18n/nb.json
+++ b/wowup-electron/src/assets/i18n/nb.json
@@ -8,6 +8,7 @@
       "IGNORED": "Ignorert",
       "INSTALL": "Installer",
       "UNINSTALL": "Avinstaller",
+      "UNKNOWN": "",
       "UPDATE": "Oppdater",
       "UPTODATE": "Oppdatert"
     },

--- a/wowup-electron/src/assets/i18n/pt.json
+++ b/wowup-electron/src/assets/i18n/pt.json
@@ -8,6 +8,7 @@
       "IGNORED": "Ignored",
       "INSTALL": "Install",
       "UNINSTALL": "Uninstall",
+      "UNKNOWN": "",
       "UPDATE": "Update",
       "UPTODATE": "Up to date"
     },

--- a/wowup-electron/src/assets/i18n/ru.json
+++ b/wowup-electron/src/assets/i18n/ru.json
@@ -8,6 +8,7 @@
       "IGNORED": "Игнорируется",
       "INSTALL": "Установить",
       "UNINSTALL": "Удалить",
+      "UNKNOWN": "",
       "UPDATE": "Обновить",
       "UPTODATE": "Актуальная"
     },

--- a/wowup-electron/src/assets/i18n/zh.json
+++ b/wowup-electron/src/assets/i18n/zh.json
@@ -8,6 +8,7 @@
       "IGNORED": "IGNORED",
       "INSTALL": "INSTALL",
       "UNINSTALL": "UNINSTALL",
+      "UNKNOWN": "",
       "UPDATE": "UPDATE",
       "UPTODATE": "UPTODATE"
     },


### PR DESCRIPTION
When there is an update available, the dialog was showing "Install" instead of "Update". Additionally I've made the texts use the translations. The problem was a fall-through where "Update" got the "Install" text.

![image](https://user-images.githubusercontent.com/1754678/97116081-19c6e680-16fb-11eb-95e9-c3b4f9153c9e.png)
