### PR TITLE
fix(electron): show loader on initial get addons click

### DIFF
--- a/wowup-electron/src/app/pages/get-addons/get-addons.component.html
+++ b/wowup-electron/src/app/pages/get-addons/get-addons.component.html
@@ -79,9 +79,18 @@
     </div>
   </div>
 
-  <app-progress-spinner *ngIf="isBusy === true"></app-progress-spinner>
+  <div class="spinner-container flex-grow-1" *ngIf="isBusy === true">
+    <app-progress-spinner> </app-progress-spinner>
+  </div>
 
-  <div class="table-container flex-grow-1" [hidden]="isBusy === true">
+  <div
+    *ngIf="isBusy === false && dataSource.data.length === 0"
+    class="no-addons-container flex-grow-1"
+  >
+    <h1>{{ 'COMMON.SEARCH.NO_ADDONS' | translate }}</h1>
+  </div>
+
+  <div class="table-container flex-grow-1" [hidden]="isBusy === true || dataSource.data.length === 0">
     <table
       mat-table
       matSort

--- a/wowup-electron/src/app/pages/get-addons/get-addons.component.scss
+++ b/wowup-electron/src/app/pages/get-addons/get-addons.component.scss
@@ -1,5 +1,10 @@
 @import "../../../variables.scss";
 
+.tab-container {
+  display: flex;
+  flex-direction: column;
+}
+
 .control-container {
   display: flex;
   flex-direction: row;
@@ -31,6 +36,16 @@
       }
     }
   }
+}
+
+.no-addons-container {
+  text-align: center;
+  color: $white-1;
+}
+.spinner-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .table-container {

--- a/wowup-electron/src/app/pages/get-addons/get-addons.component.ts
+++ b/wowup-electron/src/app/pages/get-addons/get-addons.component.ts
@@ -72,7 +72,7 @@ export class GetAddonsComponent implements OnInit, OnDestroy {
   }
 
   public query = "";
-  public isBusy = false;
+  public isBusy = true;
   public selectedClient = WowClientType.None;
 
   constructor(
@@ -198,6 +198,7 @@ export class GetAddonsComponent implements OnInit, OnDestroy {
       this.formatAddons(this.filterInstalledAddons(searchResults))
     );
     this.isBusy = false;
+    this._cdRef.detectChanges();
   }
 
   openDetailDialog(listItem: GetAddonListItem) {

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.html
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.html
@@ -106,7 +106,7 @@
     *ngIf="isBusy === false && sortedListItems.length === 0"
     class="no-addons-container flex-grow-1"
   >
-    <h1>No Addons found</h1>
+    <h1>{{ 'COMMON.SEARCH.NO_ADDONS' | translate }}</h1>
   </div>
 
   <div

--- a/wowup-electron/src/assets/i18n/de.json
+++ b/wowup-electron/src/assets/i18n/de.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Laden..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Loading..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/es.json
+++ b/wowup-electron/src/assets/i18n/es.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Loading..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/fr.json
+++ b/wowup-electron/src/assets/i18n/fr.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Loading..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/it.json
+++ b/wowup-electron/src/assets/i18n/it.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Caricamento in corso..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/ko.json
+++ b/wowup-electron/src/assets/i18n/ko.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Loading..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/nb.json
+++ b/wowup-electron/src/assets/i18n/nb.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Laster..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/pt.json
+++ b/wowup-electron/src/assets/i18n/pt.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Loading..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/ru.json
+++ b/wowup-electron/src/assets/i18n/ru.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Загрузка..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {

--- a/wowup-electron/src/assets/i18n/zh.json
+++ b/wowup-electron/src/assets/i18n/zh.json
@@ -48,6 +48,9 @@
     },
     "PROGRESS_SPINNER": {
       "LOADING": "Loading..."
+    },
+    "SEARCH": {
+      "NO_ADDONS": "No addons found"
     }
   },
   "DIALOGS": {


### PR DESCRIPTION
Format loader the same as my addons.
Hide loader when no search results found.
Add new translation for 'No addons found'.