### PR TITLE
[2.x] Use a <div> instead of <p> for option titles

### DIFF
--- a/wowup-electron/src/app/components/options-app-section/options-app-section.component.html
+++ b/wowup-electron/src/app/components/options-app-section/options-app-section.component.html
@@ -55,7 +55,7 @@
   <div class="toggle">
     <div class="row align-items-center">
       <div class="flex-grow-1">
-        <p> {{ "PAGES.OPTIONS.APPLICATION.START_WITH_SYSTEM_LABEL" | translate }} </p>
+        <div> {{ "PAGES.OPTIONS.APPLICATION.START_WITH_SYSTEM_LABEL" | translate }} </div>
         <small class="hint">{{ "PAGES.OPTIONS.APPLICATION.START_WITH_SYSTEM_DESCRIPTION" | translate }}</small>
       </div>
       <mat-slide-toggle [(ngModel)]="startWithSystem" [(checked)]="startWithSystem"
@@ -68,7 +68,7 @@
   <div class="toggle">
     <div class="row align-items-center">
       <div class="flex-grow-1">
-        <p> {{ "PAGES.OPTIONS.APPLICATION.START_MINIMIZED_LABEL" | translate }} </p>
+        <div> {{ "PAGES.OPTIONS.APPLICATION.START_MINIMIZED_LABEL" | translate }} </div>
         <small class="hint">{{ "PAGES.OPTIONS.APPLICATION.START_MINIMIZED_DESCRIPTION" | translate }}</small>
       </div>
       <mat-slide-toggle [(ngModel)]="startMinimized" [(disabled)]="!startWithSystem" [(checked)]="startMinimized"


### PR DESCRIPTION
Everything is using divs except that last 2 options, causing inconsistent styling.

### Old
![image](https://user-images.githubusercontent.com/1754678/97735505-b5c96700-1ada-11eb-9eca-276b70437683.png)

### New
![image](https://user-images.githubusercontent.com/1754678/97735398-93374e00-1ada-11eb-951a-43222c175c92.png)
