### PR TITLE
[2.0] Increase tooltip font size

### DIFF
--- a/wowup-electron/src/styles.scss
+++ b/wowup-electron/src/styles.scss
@@ -425,3 +425,7 @@ snack-bar-container {
     }
   }
 }
+
+.mat-tooltip {
+  font-size: 0.95em;
+}


### PR DESCRIPTION
Tooltips felt smaller than the rest of the applications and were harder for me to read, increased the size a little.


### Before
![image](https://user-images.githubusercontent.com/1754678/98167933-23660080-1eea-11eb-88d1-435d8836ffdc.png)

### After
![image](https://user-images.githubusercontent.com/1754678/98167904-16491180-1eea-11eb-83f5-b5e8e24c7e66.png)

### Full view
![image](https://user-images.githubusercontent.com/1754678/98167888-0e896d00-1eea-11eb-94d2-ebdc3dacf21a.png)
