### PR TITLE
fix: select the latest file based on priority channels

### DIFF
--- a/wowup-electron/src/app/business-objects/get-addon-list-item.ts
+++ b/wowup-electron/src/app/business-objects/get-addon-list-item.ts
@@ -34,6 +34,8 @@ export class GetAddonListItem {
   }
 
   public getLatestFile(channel: AddonChannelType): AddonSearchResultFile {
-    return _.find(this.searchResult.files, (f) => f.channelType <= channel);
+    let files = _.filter(this.searchResult.files, (f) => f.channelType <= channel);
+    files = _.orderBy(files, ["releaseDate"]).reverse();
+    return _.first(files);
   }
 }


### PR DESCRIPTION
If the default install channel is alpha but there's a newer beta/stable, use that file instead.

Fix #329 