### PR TITLE
fix: set indeterminate value in bulk context menu

### DIFF
--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.html
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.html
@@ -376,14 +376,16 @@
     <mat-divider></mat-divider>
     <mat-checkbox
       class="mat-menu-item"
-      [checked]="isSelectedItemsProp(listItems, 'addon.isIgnored')"
+      [indeterminate]="isIndeterminate(listItems, 'addon.isIgnored')"
+      [checked]="isAllItemsSelected(listItems, 'addon.isIgnored')"
       (change)="onClickIgnoreAddons($event, listItems)"
     >
       {{ "PAGES.MY_ADDONS.ADDON_CONTEXT_MENU.IGNORE_ADDON_BUTTON" | translate }}
     </mat-checkbox>
     <mat-checkbox
       class="mat-menu-item"
-      [checked]="isSelectedItemsProp(listItems, 'addon.autoUpdateEnabled')"
+      [indeterminate]="isIndeterminate(listItems, 'addon.autoUpdateEnabled')"
+      [checked]="isAllItemsSelected(listItems, 'addon.autoUpdateEnabled')"
       (change)="onClickAutoUpdateAddons($event, listItems)"
     >
       {{ "PAGES.MY_ADDONS.ADDON_CONTEXT_MENU.AUTO_UPDATE_ADDON_BUTTON" | translate }}

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
@@ -486,8 +486,12 @@ export class MyAddonsComponent implements OnInit, OnDestroy {
     this.loadAddons(this.selectedClient);
   }
 
-  public isSelectedItemsProp(listItems: AddonViewModel[], prop: string) {
-    return _.some(listItems, prop);
+  public isIndeterminate(listItems: AddonViewModel[], prop: string) {
+    return _.some(listItems, prop) && !this.isAllItemsSelected(listItems, prop);
+  }
+
+  public isAllItemsSelected(listItems: AddonViewModel[], prop: string) {
+    return _.filter(listItems, prop).length === listItems.length;
   }
 
   private lazyLoad() {


### PR DESCRIPTION
When selecting multiple addons in the my addons page, set the ignored/autoupdate checkbox to indeterminate if some items are set.

![video_2020-11-04 19-04-30](https://user-images.githubusercontent.com/7883662/98194949-6f5a7a80-1ed5-11eb-965c-8b76457625f0.gif)
