### PR TITLE
fix(2.x): take user to github to download portable update

### DIFF
--- a/wowup-electron/main.ts
+++ b/wowup-electron/main.ts
@@ -23,6 +23,7 @@ import { WindowState } from "./src/common/models/window-state";
 import { AppOptions } from "./src/common/wowup/app-options";
 
 const preferenceStore = new Store({ name: "preferences" });
+const isPortable = !!process.env.PORTABLE_EXECUTABLE_DIR;
 
 let appIsQuitting = false;
 let win: BrowserWindow = null;
@@ -51,7 +52,9 @@ if (preferenceStore.get(USE_HARDWARE_ACCELERATION_PREFERENCE_KEY) === "false") {
 
 app.commandLine.appendSwitch("disable-features", "OutOfBlinkCors");
 
-const USER_AGENT = `WowUp-Client/${app.getVersion()} (${release()}; ${arch()}; +https://wowup.io)`;
+const USER_AGENT = `WowUp-Client/${app.getVersion()} (${release()}; ${arch()};${
+  isPortable ? " portable;" : ""
+} +https://wowup.io)`;
 log.info("USER_AGENT", USER_AGENT);
 
 const argv = require("minimist")(process.argv.slice(1), {

--- a/wowup-electron/src/app/components/footer/footer.component.ts
+++ b/wowup-electron/src/app/components/footer/footer.component.ts
@@ -3,8 +3,8 @@ import { MatDialog } from "@angular/material/dialog";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { TranslateService } from "@ngx-translate/core";
 import { ElectronService } from "app/services";
-import { REPOSITORY_URL } from "../../../common/constants";
 import { UpdateCheckResult } from "electron-updater";
+import { AppConfig } from "environments/environment";
 import { SessionService } from "../../services/session/session.service";
 import { WowUpService } from "../../services/wowup/wowup.service";
 import { ConfirmDialogComponent } from "../confirm-dialog/confirm-dialog.component";
@@ -21,7 +21,7 @@ export class FooterComponent implements OnInit {
   public isCheckingForUpdates = false;
   public isWowUpdateDownloading = false;
   public updateIconTooltip = "APP.WOWUP_UPDATE.TOOLTIP";
-  
+
   constructor(
     private _dialog: MatDialog,
     private _translateService: TranslateService,
@@ -30,7 +30,7 @@ export class FooterComponent implements OnInit {
     public wowUpService: WowUpService,
     public sessionService: SessionService,
     private _snackBar: MatSnackBar,
-    private _electronService: ElectronService,
+    private _electronService: ElectronService
   ) {}
 
   ngOnInit(): void {
@@ -108,8 +108,10 @@ export class FooterComponent implements OnInit {
       if (!result) {
         return;
       }
-      
-      this._electronService.shell.openExternal(`${REPOSITORY_URL}/releases/tag/v${this.wowUpService.availableVersion}`);
+
+      this._electronService.shell.openExternal(
+        `${AppConfig.wowupRepositoryUrl}/releases/tag/v${this.wowUpService.availableVersion}`
+      );
     });
 
     return;

--- a/wowup-electron/src/app/pages/home/home.component.ts
+++ b/wowup-electron/src/app/pages/home/home.component.ts
@@ -1,13 +1,6 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  OnInit,
-} from "@angular/core";
+import { AfterViewInit, ChangeDetectionStrategy, Component } from "@angular/core";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { TranslateService } from "@ngx-translate/core";
-import { UpdateCheckResult } from "electron-updater";
-import { forkJoin } from "rxjs";
 import { ElectronService } from "../../services";
 import { SessionService } from "../../services/session/session.service";
 import { WarcraftService } from "../../services/warcraft/warcraft.service";
@@ -19,7 +12,7 @@ import { WowUpService } from "../../services/wowup/wowup.service";
   styleUrls: ["./home.component.scss"],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HomeComponent implements OnInit, AfterViewInit {
+export class HomeComponent implements AfterViewInit {
   public selectedIndex = 0;
   public hasWowClient = false;
 
@@ -40,10 +33,6 @@ export class HomeComponent implements OnInit, AfterViewInit {
         this.selectedIndex = this.hasWowClient ? 0 : 3;
       }
     });
-  }
-
-  ngOnInit(): void {
-    this._wowupService.wowupUpdateCheck$.subscribe(this.showUpdateSnackbar);
   }
 
   ngAfterViewInit(): void {
@@ -67,18 +56,4 @@ export class HomeComponent implements OnInit, AfterViewInit {
       console.error(e);
     }
   }
-
-  private showUpdateSnackbar = async (updateCheckResult: UpdateCheckResult) => {
-    // Have to wait for the localize service to start
-    // const [sbtext, sbaction] = await forkJoin([
-    //   this._translateService.get("APP.WOWUP_UPDATE_SNACKBAR_TEXT"),
-    //   this._translateService.get("APP.WOWUP_UPDATE_SNACKBAR_ACTION"),
-    // ]).toPromise();
-    // const snackBarRef = this._snackBar.open(sbtext, sbaction, {
-    //   duration: 2000,
-    // });
-    // snackBarRef.onAction().subscribe(() => {
-    //   console.log("The snack-bar action was triggered!");
-    // });
-  };
 }

--- a/wowup-electron/src/app/services/electron/electron.service.ts
+++ b/wowup-electron/src/app/services/electron/electron.service.ts
@@ -40,6 +40,7 @@ export class ElectronService {
   public readonly isWin = process.platform === "win32";
   public readonly isMac = process.platform === "darwin";
   public readonly isLinux = process.platform === "linux";
+  public readonly isPortable = !!process.env.PORTABLE_EXECUTABLE_DIR;
   public readonly appOptions: AppOptions;
 
   public get isElectron(): boolean {

--- a/wowup-electron/src/app/services/wowup/wowup.service.ts
+++ b/wowup-electron/src/app/services/wowup/wowup.service.ts
@@ -48,6 +48,7 @@ export class WowUpService {
   private readonly _wowupUpdateDownloadedSrc = new Subject<any>();
   private readonly _wowupUpdateCheckSrc = new Subject<UpdateCheckResult>();
   private readonly _wowupUpdateCheckInProgressSrc = new Subject<boolean>();
+  private _availableVersion = "";
 
   public readonly updaterName = "WowUpUpdater.exe";
 
@@ -74,7 +75,7 @@ export class WowUpService {
   ) {
     this.setDefaultPreferences();
 
-    this.applicationVersion = _electronService.remote.app.getVersion();
+    this.applicationVersion = _electronService.remote.app.getVersion() + `${this._electronService.isPortable ? ' (portable)' : ''}`;
     this.isBetaBuild = this.applicationVersion.toLowerCase().indexOf("beta") != -1;
 
     this.createDownloadDirectory().then(() => this.cleanupDownloads());
@@ -103,6 +104,10 @@ export class WowUpService {
     this.setAutoStartup();
 
     console.log("loginItemSettings", this._electronService.loginItemSettings);
+  }
+
+  public get availableVersion() {
+    return this._availableVersion;
   }
 
   public get updaterExists() {
@@ -265,6 +270,7 @@ export class WowUpService {
 
     // only notify things when the version changes
     if (!this.isSameVersion(updateCheckResult)) {
+      this._availableVersion = updateCheckResult.updateInfo.version;
       this._wowupUpdateCheckSrc.next(updateCheckResult);
     }
 

--- a/wowup-electron/src/assets/i18n/de.json
+++ b/wowup-electron/src/assets/i18n/de.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Öffnen"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "WowUp Update installieren",
+      "INSTALL_MESSAGE": "Willst du WowUp neu Starten um das Update zu installieren?",
+      "INSTALL_TITLE": "WowUp Update bereit",
       "NOT_AVAILABLE": "Die aktuellste Version von WowUp ist bereits installiert",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Update",
+      "SNACKBAR_TEXT": "Eine neue Version von WowUp ist verfügbar",
+      "TOOLTIP": "WowUp Update verfügbar",
       "UPDATE_ERROR": "WowUp konnte nicht nach Updates suchen"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "WowUp Update installieren",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Willst du WowUp neu Starten um das Update zu installieren?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "WowUp Update bereit",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Update",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "Eine neue Version von WowUp ist verfügbar",
-    "WOWUP_UPDATE_TOOLTIP": "WowUp Update verfügbar"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Show"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Install WowUp update",
+      "INSTALL_MESSAGE": "Do you want to restart WowUp and install the update?",
+      "INSTALL_TITLE": "WowUp Update Ready",
       "NOT_AVAILABLE": "Latest version of WowUp is already installed",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Update",
+      "SNACKBAR_TEXT": "A new version of WowUp is available",
+      "TOOLTIP": "WowUp update available",
       "UPDATE_ERROR": "Failed to get WowUp update"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Install WowUp update",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Do you want to restart WowUp and install the update?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "WowUp Update Ready",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Update",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "A new version of WowUp is available",
-    "WOWUP_UPDATE_TOOLTIP": "WowUp update available"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/es.json
+++ b/wowup-electron/src/assets/i18n/es.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Show"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Install WowUp update",
+      "INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
+      "INSTALL_TITLE": "WowUp Update Ready",
       "NOT_AVAILABLE": "Latest version of WowUp is already installed",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Update",
+      "SNACKBAR_TEXT": "A new version of WowUp is available",
+      "TOOLTIP": "WowUp update available",
       "UPDATE_ERROR": "Failed to get WowUp update"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Install WowUp update",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "WowUp Update Ready",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Update",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "A new version of WowUp is available",
-    "WOWUP_UPDATE_TOOLTIP": "WowUp update available"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/fr.json
+++ b/wowup-electron/src/assets/i18n/fr.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Show"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Install WowUp update",
+      "INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
+      "INSTALL_TITLE": "WowUp Update Ready",
       "NOT_AVAILABLE": "Latest version of WowUp is already installed",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Update",
+      "SNACKBAR_TEXT": "A new version of WowUp is available",
+      "TOOLTIP": "WowUp update available",
       "UPDATE_ERROR": "Failed to get WowUp update"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Install WowUp update",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "WowUp Update Ready",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Update",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "A new version of WowUp is available",
-    "WOWUP_UPDATE_TOOLTIP": "WowUp update available"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/it.json
+++ b/wowup-electron/src/assets/i18n/it.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Mostra"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Installa l'aggiornamento di WowUp",
+      "INSTALL_MESSAGE": "Vuoi riavviare WowUp per installare l'aggiornamento?",
+      "INSTALL_TITLE": "Aggiornamento di Wowup pronto",
       "NOT_AVAILABLE": "L'ultima versione di Wowup è già installata",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Aggiorna",
+      "SNACKBAR_TEXT": "È disponibile una nuova versione di WowUp",
+      "TOOLTIP": "L'aggiornamento di WowUp è pronto per l'installazione",
       "UPDATE_ERROR": "Errore nell'ottenere l'ultima versione di Wowup"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Installa l'aggiornamento di WowUp",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Vuoi riavviare WowUp per installare l'aggiornamento?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "Aggiornamento di Wowup pronto",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Aggiorna",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "È disponibile una nuova versione di WowUp",
-    "WOWUP_UPDATE_TOOLTIP": "L'aggiornamento di WowUp è pronto per l'installazione"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/ko.json
+++ b/wowup-electron/src/assets/i18n/ko.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Show"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Install WowUp update",
+      "INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
+      "INSTALL_TITLE": "WowUp Update Ready",
       "NOT_AVAILABLE": "Latest version of WowUp is already installed",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Update",
+      "SNACKBAR_TEXT": "A new version of WowUp is available",
+      "TOOLTIP": "WowUp update available",
       "UPDATE_ERROR": "Failed to get WowUp update"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Install WowUp update",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "WowUp Update Ready",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Update",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "A new version of WowUp is available",
-    "WOWUP_UPDATE_TOOLTIP": "WowUp update available"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/nb.json
+++ b/wowup-electron/src/assets/i18n/nb.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Show"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Installer oppdatering til WowUp",
+      "INSTALL_MESSAGE": "Vil du restarte WowUp for å installere oppdateringen?",
+      "INSTALL_TITLE": "WowUp-oppdatering er klar",
       "NOT_AVAILABLE": "Latest version of WowUp is already installed",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Oppdater",
+      "SNACKBAR_TEXT": "en ny versjon av WowUp er tilgjengelig",
+      "TOOLTIP": "WowUp oppdatering tilgjengelig",
       "UPDATE_ERROR": "Failed to get WowUp update"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Installer oppdatering til WowUp",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Vil du restarte WowUp for å installere oppdateringen?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "WowUp-oppdatering er klar",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Oppdater",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "en ny versjon av WowUp er tilgjengelig",
-    "WOWUP_UPDATE_TOOLTIP": "WowUp oppdatering tilgjengelig"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/pt.json
+++ b/wowup-electron/src/assets/i18n/pt.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Mostrar"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Instalar atualização do WowUp",
+      "INSTALL_MESSAGE": "Você gostaria de reiniciar o WowUp para instalar a atualização?",
+      "INSTALL_TITLE": "Atualização do WowUp Pronta",
       "NOT_AVAILABLE": "A última atualização do WowUp já está instalada",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Atualizar",
+      "SNACKBAR_TEXT": "Uma nova versão do WowUp está disponível",
+      "TOOLTIP": "Atualização do WowUp disponível",
       "UPDATE_ERROR": "Não foi possível atualizar o WowUp"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Instalar atualização do WowUp",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Você gostaria de reiniciar o WowUp para instalar a atualização?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "Atualização do WowUp Pronta",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Atualizar",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "Uma nova versão do WowUp está disponível",
-    "WOWUP_UPDATE_TOOLTIP": "Atualização do WowUp disponível"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/ru.json
+++ b/wowup-electron/src/assets/i18n/ru.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Показать"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Установить обновление WowUp",
+      "INSTALL_MESSAGE": "Вы хотите перезапустить WowUp чтобы установить обновление?",
+      "INSTALL_TITLE": "Для WowUp готово обновление",
       "NOT_AVAILABLE": "Последняя версия WowUp уже установлена",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Обновить",
+      "SNACKBAR_TEXT": "Доступна новая версия WowUp",
+      "TOOLTIP": "Доступно обновление для WowUp",
       "UPDATE_ERROR": "Неудачная попытка получить обновление для WowUp"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Установить обновление WowUp",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Вы хотите перезапустить WowUp чтобы установить обновление?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "Для WowUp готово обновление",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Обновить",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "Доступна новая версия WowUp",
-    "WOWUP_UPDATE_TOOLTIP": "Доступно обновление для WowUp"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/assets/i18n/zh.json
+++ b/wowup-electron/src/assets/i18n/zh.json
@@ -8,15 +8,17 @@
       "SHOW_ACTION": "Show"
     },
     "WOWUP_UPDATE": {
+      "DOWNLOADED_TOOLTIP": "Install WowUp update",
+      "INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
+      "INSTALL_TITLE": "WowUp Update Ready",
       "NOT_AVAILABLE": "Latest version of WowUp is already installed",
+      "PORTABLE_DOWNLOAD_MESSAGE": "Do you want to manually download the latest portable version?\n\nYou will need to close the app manually and copy over the new version.",
+      "PORTABLE_DOWNLOAD_TITLE": "Manual Download Required",
+      "SNACKBAR_ACTION": "Update",
+      "SNACKBAR_TEXT": "A new version of WowUp is available",
+      "TOOLTIP": "WowUp update available",
       "UPDATE_ERROR": "Failed to get WowUp update"
-    },
-    "WOWUP_UPDATE_DOWNLOADED_TOOLTIP": "Install WowUp update",
-    "WOWUP_UPDATE_INSTALL_MESSAGE": "Do you want restart WowUp to install the update?",
-    "WOWUP_UPDATE_INSTALL_TITLE": "WowUp Update Ready",
-    "WOWUP_UPDATE_SNACKBAR_ACTION": "Update",
-    "WOWUP_UPDATE_SNACKBAR_TEXT": "A new version of WowUp is available",
-    "WOWUP_UPDATE_TOOLTIP": "WowUp update available"
+    }
   },
   "COMMON": {
     "ADDON_STATE": {

--- a/wowup-electron/src/common/constants.ts
+++ b/wowup-electron/src/common/constants.ts
@@ -44,3 +44,6 @@ export const APP_UPDATE_INSTALL = "app-update-install";
 export const APP_UPDATE_CHECK_FOR_UPDATE = "app-update-check-for-update";
 export const APP_UPDATE_CHECK_START = "app-update-check-start";
 export const APP_UPDATE_CHECK_END = "app-update-check-end";
+
+// RESOURCES
+export const REPOSITORY_URL = "https://github.com/jliddev/WowUp";

--- a/wowup-electron/src/common/constants.ts
+++ b/wowup-electron/src/common/constants.ts
@@ -44,6 +44,3 @@ export const APP_UPDATE_INSTALL = "app-update-install";
 export const APP_UPDATE_CHECK_FOR_UPDATE = "app-update-check-for-update";
 export const APP_UPDATE_CHECK_START = "app-update-check-start";
 export const APP_UPDATE_CHECK_END = "app-update-check-end";
-
-// RESOURCES
-export const REPOSITORY_URL = "https://github.com/jliddev/WowUp";

--- a/wowup-electron/src/environments/environment.ts
+++ b/wowup-electron/src/environments/environment.ts
@@ -5,6 +5,7 @@ export const AppConfig = {
   wowUpHubUrl: "https://hub.dev.wowup.io",
   rollbarAccessKey: "d01c11314a064572b11acee18d880650",
   googleAnalyticsId: "UA-92563227-4",
+  wowupRepositoryUrl: "https://github.com/jliddev/WowUp",
   firebaseConfig: {
     apiKey: "AIzaSyBvZ1_ldinsxeh-iRI53REm8j1CPcQuIBw",
     authDomain: "wowup-893c6.firebaseapp.com",


### PR DESCRIPTION
Instead of automatically downloading the installer for potable users, take them to GitHub to manually download the latest portable.
Move WOWUP_UPDATE translations to new section.
Remove unused snackbar code in home component.

Fix #331 